### PR TITLE
Update python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
         "(LGPLv3)",
         "Operating System :: POSIX :: Linux",
     ],
-    python_requires='==3',
+    python_requires='>=3',
 )


### PR DESCRIPTION
When trying to install with `pip -e`, I had to make this change to install with python 3.7.3. Not sure if `python setup.py install` would have handled it better, but I suspect it would not hurt it.