### PR TITLE
Remove pathlib requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url='https://github.com/kalemaria/pycurv',
     packages=find_packages(),
     install_requires=["numpy", "scipy", "scikit-image", "pandas", "pytest",
-                      "matplotlib", "pathlib", "vtk", "nibabel",
+                      "matplotlib", "vtk", "nibabel",
                       "pathos", "networkx", "future", "doit"],
     classifiers=[
         "Programming Language :: Python :: 3",
@@ -23,5 +23,5 @@ setup(
         "(LGPLv3)",
         "Operating System :: POSIX :: Linux",
     ],
-    python_requires='>=3',
+    python_requires='>=3.4',
 )


### PR DESCRIPTION
Pathlib has been built in since python 3.4, and the pip version hasn't been updated since 2014. Everything worked fine for my testing, but apparently on newer macs the pip version of pathlib won't install properly. With python >3.4 pycurv seems to run fine without the pathlib install.  I bumped the python requirement and removed the pathlib requirement