### PR TITLE
Remove deprecated calls to np.int and np.float

### DIFF
--- a/pycurv/graphs.py
+++ b/pycurv/graphs.py
@@ -349,7 +349,7 @@ class SegmentationGraph(object):
             print('edge arrays length: {}'.format(len(edge_arrays)))
 
         # Geometry
-        lut = np.zeros(shape=self.graph.num_vertices(), dtype=np.int)
+        lut = np.zeros(shape=self.graph.num_vertices(), dtype=int)
         for i, vd in enumerate(self.graph.vertices()):
             [x, y, z] = self.graph.vp.xyz[vd]
             points.InsertPoint(i, x, y, z)

--- a/pycurv/pycurv_io.py
+++ b/pycurv/pycurv_io.py
@@ -577,7 +577,7 @@ class TypesConverter(object):
             return np.bool
         elif (isinstance(din, vtk.vtkIntArray) or
                 isinstance(din, vtk.vtkTypeInt32Array)):
-            return np.int
+            return np.int32
         elif isinstance(din, vtk.vtkTypeInt8Array):
             return np.int8
         elif isinstance(din, vtk.vtkTypeInt16Array):
@@ -665,7 +665,7 @@ class TypesConverter(object):
         elif (din == 'int64_t') or (din == 'vector<int64_t>'):
             return np.int64
         elif (din == 'double') or (din == 'vector<double>'):
-            return np.float
+            return float
         else:
             raise pexceptions.PySegInputError(
                 expr='gt_to_numpy (TypesConverter)',

--- a/pycurv/surface.py
+++ b/pycurv/surface.py
@@ -241,9 +241,9 @@ def gen_surface(tomo, lbl=1, mask=True, other_mask=None, purge_ratio=1,
                         norm[2] = 0
                         pnorm = (i_x, i_y, 0)
                         p = (x, y, 0)
-                        dprod = dot_norm(np.asarray(p, dtype=np.float),
-                                         np.asarray(pnorm, dtype=np.float),
-                                         np.asarray(norm, dtype=np.float))
+                        dprod = dot_norm(np.asarray(p, dtype=np.float32),
+                                         np.asarray(pnorm, dtype=np.float32),
+                                         np.asarray(norm, dtype=np.float32))
                         tomod[x, y, z] = tomod[x, y, z] * np.sign(dprod)
         else:
             for x in range(nx):
@@ -258,9 +258,9 @@ def gen_surface(tomo, lbl=1, mask=True, other_mask=None, purge_ratio=1,
                         # norm[2] = hold_norm[2]
                         pnorm = (i_x, i_y, i_z)
                         p = (x, y, z)
-                        dprod = dot_norm(np.asarray(pnorm, dtype=np.float),
-                                         np.asarray(p, dtype=np.float),
-                                         np.asarray(norm, dtype=np.float))
+                        dprod = dot_norm(np.asarray(pnorm, dtype=np.float32),
+                                         np.asarray(p, dtype=np.float32),
+                                         np.asarray(norm, dtype=np.float32))
                         tomod[x, y, z] = tomod[x, y, z] * np.sign(dprod)
 
         if verbose:
@@ -318,7 +318,7 @@ def gen_isosurface(tomo, lbl, grow=0, sg=0, thr=1.0, mask=None):
 
     # Smoothing
     if sg > 0:
-        binary_seg = gaussian_filter(binary_seg.astype(np.float), sg)
+        binary_seg = gaussian_filter(binary_seg.astype(np.float32), sg)
 
     # Generate isosurface
     smoothed_seg_vti = io.numpy_to_vti(binary_seg)

--- a/pycurv/surface_graphs.py
+++ b/pycurv/surface_graphs.py
@@ -1435,7 +1435,7 @@ class TriangleGraph(SurfaceGraph):
             # Geometry
             # lut[vertex_index, triangle_point_index*] = point_array_index**
             # *ALWAYS 0-2, **0-(NumPoints-1)
-            lut = np.zeros(shape=(self.graph.num_vertices(), 3), dtype=np.int)
+            lut = np.zeros(shape=(self.graph.num_vertices(), 3), dtype=int)
             i = 0  # next new point index
             # dictionary of points with a key (x, y, z) and the index in VTK
             # points list as a value

--- a/pycurv_testing/plotting.py
+++ b/pycurv_testing/plotting.py
@@ -2257,13 +2257,13 @@ def plot_peak_curvature_diff_rh(
         selection = df.query('(segmentation==@segmentation) & (method==@method)'
                              '& (radius_hit==@radius_hit)')
         curvatures = selection[curvature].values[0]
-        curvatures_array = np.array(curvatures).astype(np.float)
+        curvatures_array = np.array(curvatures).astype(np.float32)
         curvatures_arrays.append(curvatures_array)
         label = r"rh={}".format(radius_hit)
         labels.append(label)
         if weights is not None:
             weights = selection[weights].values[0]
-            weights_array = np.array(weights).astype(np.float)
+            weights_array = np.array(weights).astype(np.float32)
             weights_arrays.append(weights_array)
 
     if x_range is None:

--- a/pycurv_testing/synthetic_volumes.py
+++ b/pycurv_testing/synthetic_volumes.py
@@ -319,7 +319,7 @@ def main():
     # Gaussian smoothing
     sigma = 0.2
     smooth_sphere = ndimage.filters.gaussian_filter(
-        sphere.astype(np.float), sigma)
+        sphere.astype(np.float32), sigma)
     print(np.min(smooth_sphere))
     print(np.max(smooth_sphere))
     io.save_numpy(smooth_sphere, "{}smooth_sphere_r{}_t{}_box{}.mrc".format(

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
         "(LGPLv3)",
         "Operating System :: POSIX :: Linux",
     ],
-    python_requires='==3',
+    python_requires='>=3.4',
 )

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
     url='https://github.com/kalemaria/pycurv',
     packages=find_packages(),
     install_requires=["numpy", "scipy", "scikit-image", "pandas", "pytest",
-                      "matplotlib", "pathlib", "vtk", "nibabel",
-                      "pathos", "networkx", "future"],
+                      "matplotlib", "vtk", "nibabel",
+                      "pathos", "networkx", "future", "doit"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU Lesser General Public License v3 "


### PR DESCRIPTION
Resolves #9 by specifying the type of int and float more specifically.